### PR TITLE
Get PowerStatus and only send TurnOff if the TV is Active

### DIFF
--- a/connection/response.go
+++ b/connection/response.go
@@ -315,3 +315,9 @@ type DualChannel struct {
 	DualChannelTypeID   string `json:"dualChannelTypeId"`
 	DualChannelNumber   string `json:"dualChannelNumber"`
 }
+
+// PowerStatus holds the state of the TV's power
+type PowerState struct {
+	ReturnValue bool   `json:"returnValue"`
+	State       string `json:"state"`
+}

--- a/control/uris.go
+++ b/control/uris.go
@@ -28,4 +28,6 @@ const (
 	uriLaunchApp = "ssap://system.launcher/launch"
 
 	uriTurnOff = "ssap://system/turnOff"
+
+	uriPowerState = "ssap://com.webos.service.tvpower/power/getPowerState"
 )


### PR DESCRIPTION
Modern OLED TVs may still be reachable over the network for a while
after turning off; it's goes to "Active Standby" mode.  In this state
this function actually turns the TV back on!  So we check the state
and only send an Off signal if the TV is currently Active